### PR TITLE
Fix typo in backend log message and refactor frontend editor mode handling

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), std::io::Error> {
                 state.identities_storage.lock().await.users.len()
             );
             info!(
-                "Arhieves storage file contains {} entries",
+                "Backups storage file contains {} entries",
                 state.backups_storage.lock().await.backups.len()
             );
             info!(

--- a/frontend/lib/services/key_mapping.dart
+++ b/frontend/lib/services/key_mapping.dart
@@ -5,18 +5,18 @@ import 'package:notes/services/user.dart';
 import 'dart:async'; 
 import 'package:collection/collection.dart'; 
 
-enum KeyContext { global, editorNormal, editorInsert, editorVisual }
+enum KeyContext { global, editorNormal, editorInsert, editorVisual, editorVisualLine }
 
 enum AppAction {
   // Global
   openConfig,
   openSearch,
   toggleSidebar,
+  refresh,
+  saveDocument,
+  closeTab, 
   switchTabNext,
   switchTabPrevious,
-  saveDocument,
-  refresh,
-  closeTab, 
 
   // Editor Navigation
   cursorMoveLeft,
@@ -25,13 +25,14 @@ enum AppAction {
   cursorMoveDown,
   gotoBeginningOfLine, 
   gotoEndOfLine, 
-
+  
   // Editor Modes
   enterInsertMode,
   enterVisualMode,
   enterVisualLineMode, 
   exitInsertMode, // Esc
   exitVisualMode, // Esc
+  
   // Editor Editing
   deleteLeft, // Backspace
   deleteRight, // Delete


### PR DESCRIPTION
- Change "Arhieves" to "Backups" in backend storage log
- Replace EditorMode enum with unified KeyContext enum
- Rename EditorShortcuts mixin to EditorActions
- Remove redundant getCurrentContext() method
- Simplify key event handling in EditorInputHandler
- Fix word navigation and selection edge cases