### PR TITLE
Add JSON serialization mixin and persistent login state

### DIFF
--- a/frontend/lib/json_serialization.dart
+++ b/frontend/lib/json_serialization.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+
+mixin JsonSerializationMixin {
+  Map<String, dynamic> toJson();
+
+  static T fromString<T>(String string, T Function(Map<String, dynamic>) fromJson) {
+    final json = jsonDecode(string);
+    return fromJson(json);
+  }
+
+  @override
+  String toString() {
+    final json = toJson();
+    return jsonEncode(json);
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -7,6 +7,12 @@ import 'package:notes/state/app_state_scope.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final state = AppState();
+
+  final username = await state.hasUserLoggedIn();
+  if (username != null) {
+    state.relogin(username);
+  }
+
   runApp(AppStateScope(notifier: state, child: const MyApp()));
 }
 

--- a/frontend/lib/screens/main_screen.dart
+++ b/frontend/lib/screens/main_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:notes/actions/handlers.dart';
 import 'package:notes/inputs/global_key_handler.dart';
+import 'package:notes/state/app_state.dart';
 import 'package:notes/state/app_state_scope.dart';
 import 'package:notes/state/activities.dart';
 import 'package:notes/widgets/content_area.dart';
@@ -40,6 +41,16 @@ class _MainScreenState extends State<MainScreen> {
     }
   }
 
+  IconButton _buildLogoutButton(AppState appState) {
+    return IconButton(
+      icon: const Icon(Icons.logout),
+      tooltip: 'Logout',
+      onPressed: () async {
+        await appState.logout();
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final appState = AppStateScope.of(context);
@@ -54,6 +65,7 @@ class _MainScreenState extends State<MainScreen> {
           title: const Text('Notes'),
           actions: [
             const NotificationCenterButton(),
+            _buildLogoutButton(appState),
             if (isDocumentActive)
               IconButton(
                 icon: const Icon(Icons.save),

--- a/frontend/lib/state/app_state.dart
+++ b/frontend/lib/state/app_state.dart
@@ -53,12 +53,27 @@ class AppState extends ChangeNotifier
       final success = await users.login(dio, username, password);
       if (success) {
         this.username = username;
+        registerLocalLoginStatus(username, true);
         notifyListeners();
         loadLastOpenedTabs();
         await refreshAll();
         return true;
       }
       return false;
+    } catch (e) {
+      return false;
+    }
+  }
+  
+  Future<bool> relogin(String username) async {
+    try {
+      this.username = username;
+      registerLocalLoginStatus(username, true);
+      notifyListeners();
+      loadLastOpenedTabs();
+      await refreshAll();
+
+      return true;
     } catch (e) {
       return false;
     }
@@ -331,7 +346,7 @@ class AppState extends ChangeNotifier
     if (!openObjectIds.contains(documentId)) {
       openObjectIds.add(documentId);
     }
-    
+
     if (highlightText != null) {
       searchHighlights[documentId] = SearchHighlight(
         highlightText,

--- a/frontend/lib/state/services.dart
+++ b/frontend/lib/state/services.dart
@@ -22,4 +22,16 @@ mixin Services {
     final response = await general.getServiceInformation(dio);
     return response.data["version"];
   }
+  
+  Future<void> setDataToLocalStorage(String identifier, String username, String content) async {
+    await localStorage.setString('${username}_$identifier', content);
+  }
+  
+  Future<String?> readDataFromLocalStorage(String identifier, String username) async {
+    return await localStorage.getString('${username}_$identifier');
+  }
+  
+  Future<void> removeDataFromLocalStorage(String identifier, String username) async {
+    await localStorage.remove('${username}_$identifier');
+  }
 }

--- a/frontend/lib/state/users.dart
+++ b/frontend/lib/state/users.dart
@@ -1,6 +1,75 @@
 import 'package:flutter/foundation.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:notes/json_serialization.dart';
 import 'package:notes/state/services.dart';
+import 'package:uuid/uuid.dart';
+
+part 'users.g.dart';
+
+@JsonSerializable()
+class LocalUserLoginRecord with JsonSerializationMixin {
+  bool hasUserLoggedIn;
+  String username;
+  String verificationHash = "xxhAzB0";
+  DateTime lastLogin = DateTime.now();
+
+  LocalUserLoginRecord(
+    this.hasUserLoggedIn,
+    this.username,
+    this.verificationHash,
+  );
+
+  factory LocalUserLoginRecord.fromJson(Map<String, dynamic> json) =>
+      _$LocalUserLoginRecordFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LocalUserLoginRecordToJson(this);
+}
 
 mixin Users on ChangeNotifier, Services {
   String? username;
+
+  void registerLocalLoginStatus(String username, bool hasLoggedIn) {
+    // We use a uuid as temporary filler.
+    // TODO: have a secure authentication for users.
+    final uuid = Uuid();
+    setDataToLocalStorage(
+      'login_status',
+      'system',
+      LocalUserLoginRecord(hasLoggedIn, username, uuid.v4()).toString(),
+    );
+  }
+
+  Future<String?> hasUserLoggedIn() async {
+    final String? content = await readDataFromLocalStorage(
+      'login_status',
+      'system',
+    );
+    if (content != null) {
+      final record = JsonSerializationMixin.fromString(
+        content,
+        LocalUserLoginRecord.fromJson,
+      );
+
+      if (DateTime.now().difference(record.lastLogin).inDays >= 30) {
+        // Remove stale entry
+        await removeDataFromLocalStorage('login_status', 'system');
+        return null;
+      }
+
+      return record.username;
+    }
+    return null;
+  }
+
+  Future<void> logout() async {
+    final String? content = await readDataFromLocalStorage(
+      'login_status',
+      'system',
+    );
+    if (content != null) {
+      await removeDataFromLocalStorage('login_status', 'system');
+    }
+    username = null;
+    notifyListeners();
+  }
 }

--- a/frontend/lib/state/users.g.dart
+++ b/frontend/lib/state/users.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'users.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+LocalUserLoginRecord _$LocalUserLoginRecordFromJson(
+  Map<String, dynamic> json,
+) => LocalUserLoginRecord(
+  json['hasUserLoggedIn'] as bool,
+  json['username'] as String,
+  json['verificationHash'] as String,
+)..lastLogin = DateTime.parse(json['lastLogin'] as String);
+
+Map<String, dynamic> _$LocalUserLoginRecordToJson(
+  LocalUserLoginRecord instance,
+) => <String, dynamic>{
+  'hasUserLoggedIn': instance.hasUserLoggedIn,
+  'username': instance.username,
+  'verificationHash': instance.verificationHash,
+  'lastLogin': instance.lastLogin.toIso8601String(),
+};


### PR DESCRIPTION
- Introduce `JsonSerializationMixin` for reusable JSON encoding/decoding
- Replace manual JSON handling in `SavedTabsStates` with mixin
- Add local login status tracking with automatic relogin on app start
- Implement logout functionality with UI button
- Extend localStorage methods with identifier support for data segregation
- Store login records with timestamp for stale entry cleanup (30-day limit)
- Generate JSON serialization code for `LocalUserLoginRecord`