### PR TITLE
Remove markdown preview and dependency

### DIFF
--- a/frontend/lib/widgets/document_editor.dart
+++ b/frontend/lib/widgets/document_editor.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:notes/inputs/editor_input_handler.dart';
 import 'package:notes/state/app_state_scope.dart';
 
@@ -217,20 +216,6 @@ class _DocumentEditorState extends State<DocumentEditor> {
                     setState(() {});
                   },
                   onSave: () => appState.saveActiveDocument(),
-                ),
-              ),
-              const VerticalDivider(width: 1),
-              Expanded(
-                child: Markdown(
-                  data: _controller.text,
-                  controller: _previewScrollController,
-                  styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
-                      .copyWith(
-                        p: Theme.of(
-                          context,
-                        ).textTheme.bodyLarge?.copyWith(height: 1.5),
-                        blockSpacing: 24.0,
-                      ),
                 ),
               ),
             ],

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -270,14 +270,6 @@ packages:
       url: "https://mirrors.tuna.tsinghua.edu.cn/dart-pub/"
     source: hosted
     version: "5.0.0"
-  flutter_markdown_plus:
-    dependency: "direct main"
-    description:
-      name: flutter_markdown_plus
-      sha256: "7f349c075157816da399216a4127096108fd08e1ac931e34e72899281db4113c"
-      url: "https://mirrors.tuna.tsinghua.edu.cn/dart-pub/"
-    source: hosted
-    version: "1.0.5"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -400,14 +392,6 @@ packages:
       url: "https://mirrors.tuna.tsinghua.edu.cn/dart-pub/"
     source: hosted
     version: "1.3.0"
-  markdown:
-    dependency: transitive
-    description:
-      name: markdown
-      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
-      url: "https://mirrors.tuna.tsinghua.edu.cn/dart-pub/"
-    source: hosted
-    version: "7.3.0"
   matcher:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -37,7 +37,6 @@ dependencies:
   dio: ^5.9.0
   json_annotation: ^4.9.0
   file_picker: ^10.3.7
-  flutter_markdown_plus: ^1.0.5
   archive: ^4.0.7
   path_provider: ^2.1.5
   uuid: ^4.5.2


### PR DESCRIPTION
No good enough markdown WYSIWYG editor in Dart so far. 

Switch to the plain text for now. 