### PR TITLE
Fix large documents failing to save to a remote server

### DIFF
--- a/crates/opennote-server/src/initialization.rs
+++ b/crates/opennote-server/src/initialization.rs
@@ -66,7 +66,8 @@ pub async fn initialize_backend_api_service(
             .wrap(Cors::permissive())
             .wrap(from_fn(check_password))
             .app_data(bootstrap.clone())
-            .app_data(PayloadConfig::new(usize::MAX))
+            // Size limit is 100 MB for now.
+            .app_data(PayloadConfig::new(100 * 1024 * 1024))
             .service(configure_routes())
         // .service(web::scope("/mcp").service(mcp_service.clone().scope()))
     });

--- a/crates/opennote-server/src/initialization.rs
+++ b/crates/opennote-server/src/initialization.rs
@@ -1,8 +1,10 @@
+use std::usize;
+
 use actix_cors::Cors;
 use actix_web::{
     App, HttpServer,
     middleware::{Logger, from_fn},
-    web::Data,
+    web::{Data, PayloadConfig},
 };
 use anyhow::{Context, Result};
 
@@ -64,6 +66,7 @@ pub async fn initialize_backend_api_service(
             .wrap(Cors::permissive())
             .wrap(from_fn(check_password))
             .app_data(bootstrap.clone())
+            .app_data(PayloadConfig::new(usize::MAX))
             .service(configure_routes())
         // .service(web::scope("/mcp").service(mcp_service.clone().scope()))
     });


### PR DESCRIPTION
We will need to implement streaming payloads in the future. But for conventional docs, 100 MB is enough. 