### PR TITLE
Fix chinese model download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
 dependencies = [
  "bytestring",
- "cfg-if",
+ "cfg-if 1.0.4",
  "http 0.2.12",
  "regex",
  "regex-lite",
@@ -184,7 +184,7 @@ dependencies = [
  "actix-web-codegen",
  "bytes",
  "bytestring",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cookie 0.16.2",
  "derive_more 2.1.1",
  "encoding_rs",
@@ -263,7 +263,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher 0.4.4",
  "cpufeatures 0.2.17",
  "zeroize",
@@ -286,7 +286,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
@@ -897,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.6.1",
@@ -942,7 +942,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.4",
  "event-listener 5.4.1",
  "futures-lite 2.6.1",
  "rustix 1.1.4",
@@ -968,7 +968,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomic-waker",
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-core",
  "futures-io",
  "rustix 1.1.4",
@@ -1176,6 +1176,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object",
@@ -1468,7 +1491,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
  "cpufeatures 0.2.17",
 ]
@@ -1614,6 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1981,6 +2005,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -2006,7 +2036,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher 0.3.0",
  "cpufeatures 0.1.5",
  "zeroize",
@@ -2018,7 +2048,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -2207,6 +2237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,6 +2329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,7 +2374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -2436,6 +2484,21 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -2603,7 +2666,7 @@ checksum = "7e4583956b9806b69f73fcb23aee05eb3620efc282972f08f6a6db7504f8334d"
 dependencies = [
  "bitflags 2.11.0",
  "block",
- "cfg-if",
+ "cfg-if 1.0.4",
  "core-foundation 0.10.0",
  "libc",
 ]
@@ -2676,6 +2739,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+dependencies = [
+ "futures-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,7 +2795,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2902,6 +2974,16 @@ checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -3095,7 +3177,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -3431,7 +3513,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.2",
  "regex",
- "sha2",
+ "sha2 0.10.9",
  "unicode-segmentation",
  "uuid",
 ]
@@ -4131,7 +4213,7 @@ dependencies = [
  "candle-transformers",
  "clap",
  "half 2.7.1",
- "hf-hub",
+ "hf-hub 1.0.0",
  "image",
  "intel-mkl-src",
  "lazy_static",
@@ -4177,7 +4259,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -4334,7 +4416,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "home",
  "windows-sys 0.48.0",
 ]
@@ -4540,7 +4622,7 @@ version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "libredox",
 ]
@@ -4773,6 +4855,12 @@ dependencies = [
  "rustix 0.38.44",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -5052,6 +5140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gearhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "gemm"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5296,12 +5393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "log",
  "rustversion",
  "windows-link 0.2.1",
- "windows-result 0.3.4",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5461,7 +5558,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -5472,7 +5569,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -5485,7 +5582,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -5499,12 +5596,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5565,6 +5664,26 @@ dependencies = [
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5750,7 +5869,7 @@ dependencies = [
  "core-text",
  "core-video",
  "cosmic-text",
- "ctor",
+ "ctor 0.4.3",
  "derive_more 0.99.20",
  "embed-resource",
  "etagere",
@@ -5809,7 +5928,7 @@ dependencies = [
  "wayland-protocols-plasma",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-numerics",
+ "windows-numerics 0.2.0",
  "windows-registry 0.5.3",
  "x11-clipboard",
  "x11rb",
@@ -5958,7 +6077,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "url",
  "zed-async-tar",
@@ -5986,7 +6105,7 @@ dependencies = [
  "bindgen",
  "core-foundation 0.10.0",
  "core-video",
- "ctor",
+ "ctor 0.4.3",
  "foreign-types 0.5.0",
  "metal",
  "objc",
@@ -6192,7 +6311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "rand 0.9.2",
@@ -6271,6 +6390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6328,6 +6453,60 @@ dependencies = [
  "thiserror 2.0.18",
  "ureq 2.12.1",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hf-hub"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ccb6bcc85dec15413ef5949879f9a5497ca4568ed702547eb83fac23376e5c"
+dependencies = [
+ "base64 0.22.1",
+ "bon",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c237ef4fb0ce1962a5117f8bd8c74454b41629826a9df17d14a1840ca18f0754"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "more-asserts",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "uuid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
 ]
 
 [[package]]
@@ -6588,7 +6767,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -6954,7 +7133,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -7156,13 +7335,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7209,7 +7418,7 @@ version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -7265,6 +7474,23 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
 ]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "kqueue"
@@ -7920,7 +8146,7 @@ dependencies = [
  "html5ever 0.29.1",
  "http 1.4.0",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "kuchikiki",
  "libc",
  "ndk",
@@ -7933,7 +8159,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",
@@ -8039,9 +8265,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -8071,7 +8297,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -8081,7 +8307,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -8093,14 +8319,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.9.1",
 ]
 
 [[package]]
@@ -8125,6 +8351,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"
@@ -8192,7 +8430,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "generator",
  "scoped-tls",
  "tracing",
@@ -8327,6 +8565,15 @@ name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -8499,7 +8746,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
@@ -8509,7 +8756,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest 0.10.7",
 ]
 
@@ -8652,7 +8899,7 @@ dependencies = [
  "anyhow",
  "clap",
  "half 2.7.1",
- "hf-hub",
+ "hf-hub 0.4.3",
  "ndarray 0.15.6",
  "safetensors 0.5.3",
  "serde_json",
@@ -8700,6 +8947,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "moxcms"
@@ -8839,7 +9092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
  "memoffset",
@@ -8852,7 +9105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
 ]
@@ -9202,6 +9455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9226,6 +9489,15 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -9338,7 +9610,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "thiserror 1.0.69",
  "toml 0.8.23",
@@ -9415,7 +9687,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.9.2",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zbus",
  "zbus_macros",
@@ -9663,7 +9935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types 0.3.2",
  "libc",
  "once_cell",
@@ -9766,9 +10038,18 @@ checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
 dependencies = [
  "flate2",
  "pkg-config",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq 3.3.0",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9860,7 +10141,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec 1.15.1",
@@ -10014,7 +10295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10367,7 +10648,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -10724,7 +11005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libm",
  "num-complex",
  "reborrow",
@@ -10738,7 +11019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libm",
  "num-complex",
  "paste",
@@ -10819,6 +11100,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -11200,7 +11482,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if",
+ "cfg-if 1.0.4",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -11326,6 +11608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11345,9 +11636,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -11500,7 +11791,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -11513,25 +11804,55 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "futures-util",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tower-service",
 ]
 
 [[package]]
@@ -11564,7 +11885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -11791,7 +12112,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "glob",
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -11849,7 +12170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -11907,7 +12228,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ordered-multimap",
 ]
 
@@ -11997,6 +12318,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -12038,11 +12360,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -12094,6 +12444,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
 name = "safetensors"
@@ -12485,7 +12841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "254a0bb6a4457058f3d3cdfed313b567cde5fec9113b39aaac730f4ee34113a9"
 dependencies = [
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "postcard",
  "rand_chacha 0.3.1",
@@ -12733,7 +13089,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -12744,7 +13100,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
@@ -12761,9 +13117,20 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -12781,7 +13148,9 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
+ "bstr",
  "dirs 6.0.0",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -12815,6 +13184,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -13116,7 +13495,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec 1.15.1",
  "thiserror 2.0.18",
  "time",
@@ -13156,7 +13535,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -13201,7 +13580,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "sha1 0.10.6",
- "sha2",
+ "sha2 0.10.9",
  "smallvec 1.15.1",
  "sqlx-core",
  "stringprep",
@@ -13209,7 +13588,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -13242,7 +13621,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec 1.15.1",
  "sqlx-core",
  "stringprep",
@@ -13250,7 +13629,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -13306,7 +13685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
  "windows-sys 0.59.0",
@@ -13338,6 +13717,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "std_prelude"
@@ -13593,6 +13982,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13669,6 +14064,20 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -13903,7 +14312,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271450eb289cb4d8d0720c6ce70c72c8c858c93dd61fc625881616752e6b98f6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "core-foundation-sys",
  "libc",
  "objc",
@@ -14051,7 +14460,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -14117,7 +14526,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "log",
  "png 0.17.16",
  "tiny-skia-path",
@@ -14172,7 +14581,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "hf-hub",
+ "hf-hub 0.4.3",
  "indicatif 0.17.11",
  "itertools 0.14.0",
  "log",
@@ -14207,7 +14616,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "hf-hub",
+ "hf-hub 0.4.3",
  "indicatif 0.18.4",
  "itertools 0.14.0",
  "log",
@@ -14268,6 +14677,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14311,6 +14731,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14515,6 +14959,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14547,6 +15004,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14556,12 +15023,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec 1.15.1",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -15029,6 +15499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15298,6 +15774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "usvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15502,6 +15984,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15526,12 +16017,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "serde",
@@ -15608,6 +16108,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -15898,7 +16411,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite 1.0.2",
+ "web-sys",
 ]
 
 [[package]]
@@ -15948,11 +16474,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -15965,7 +16503,7 @@ dependencies = [
  "rayon",
  "thiserror 2.0.18",
  "windows 0.61.3",
- "windows-future",
+ "windows-future 0.2.1",
 ]
 
 [[package]]
@@ -15975,6 +16513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -16003,6 +16550,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16010,7 +16570,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -16077,6 +16648,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16290,6 +16871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16514,7 +17104,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-sys 0.48.0",
 ]
 
@@ -16524,7 +17114,7 @@ version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-sys 0.59.0",
 ]
 
@@ -16781,6 +17371,147 @@ name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xet-client"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b8da8cc70aa2e3c500c0400e012df82c656ab9fca47f9f939fffc5afd89aca"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http 1.4.0",
+ "hyper",
+ "more-asserts",
+ "rand 0.10.1",
+ "redb",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio_with_wasm",
+ "tracing",
+ "url",
+ "urlencoding",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73503c223783dccc864abde22115e09d12f190448a0baf58ab2c54bc709e2f99"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "countio",
+ "futures",
+ "futures-util",
+ "getrandom 0.4.2",
+ "heapify",
+ "itertools 0.14.0",
+ "lz4_flex 0.13.1",
+ "more-asserts",
+ "rand 0.10.1",
+ "regex",
+ "safe-transmute",
+ "serde",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89052ec5dec2187cad30b86af92cc24fd61c4a57a795f1ff7ff5f38d49184eb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "gearhash",
+ "http 1.4.0",
+ "itertools 0.14.0",
+ "more-asserts",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5c60d5eed38ab4c576f4421bae835e7bd07631fb381705605529d2015c106b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor 1.0.12",
+ "dirs 6.0.0",
+ "futures",
+ "git-version",
+ "humantime",
+ "konst",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo 0.38.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tokio_with_wasm",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "web-time",
+ "whoami 2.1.2",
+ "winapi",
+]
 
 [[package]]
 name = "xim-ctext"
@@ -17087,7 +17818,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "windows-registry 0.4.0",
 ]
@@ -17106,7 +17837,7 @@ dependencies = [
  "rand 0.8.5",
  "screencapturekit",
  "screencapturekit-sys",
- "sysinfo",
+ "sysinfo 0.31.4",
  "tao-core-video-sys",
  "windows 0.61.3",
  "windows-capture",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A block-based, AI-powered note-taking app with semantic search — built entirel
 
 **For mac users**: I don't have an Apple Developer Account yet, so I can't codesign the mac app. You may need to run the following command in Terminal, after pasting the app file to the `Applications` folder:
 
+**For first-time installation**: The app will try downloading `models--sentence-transformers--all-MiniLM-L6-v2` from `https://huggingface.co` by default. However, in case if the official site fails, it will switch to use a mirror site, which is `https://hf-mirror.com`.
+
 ```bash
 sudo xattr -r -d com.apple.quarantine /Applications/opennote.app
 ```

--- a/crates/opennote-bootstrap/src/lib.rs
+++ b/crates/opennote-bootstrap/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result};
 use tokio::sync::Mutex;
 
 use opennote_data::Databases;
@@ -23,10 +23,9 @@ impl DesktopBootstrap {
         configurations: &DesktopConfigurations,
         key_mappings: &KeyMappingConfigurations,
     ) -> Result<Self> {
-        let embedders = match EmbedderEntry::new(&configurations.system).await {
-            Ok(result) => result,
-            Err(error) => return Err(anyhow!("Error when loading an embedding model: {}", error)),
-        };
+        let embedders = EmbedderEntry::new(&configurations.system)
+            .await
+            .context("Error when loading an embedding model")?;
 
         Ok(Self {
             configurations: Arc::new(Mutex::new(configurations.clone())),

--- a/crates/opennote-embedder/crates/embed/Cargo.toml
+++ b/crates/opennote-embedder/crates/embed/Cargo.toml
@@ -30,7 +30,7 @@ tokenizers = { version="0.22.1", features=["http"] }
 tracing = "0.1.41"
 
 # Hugging Face Libraries
-hf-hub = { version = "0.4.2", default-features = false }
+hf-hub = { version = "1.0.0", default-features = false, features = ["blocking"] }
 candle-nn = { version = "0.9.2" }
 candle-transformers = { version = "0.9.2" }
 candle-core = { version = "0.9.2" }

--- a/crates/opennote-embedder/crates/embed/src/embeddings/embed/embedder.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/embed/embedder.rs
@@ -1,6 +1,6 @@
 use crate::Dtype;
+use crate::embeddings::hub::HubClient;
 use anyhow::{Result, anyhow};
-use hf_hub::Repo;
 
 use super::text::{TextEmbed, TextEmbedder};
 use super::types::{EmbedData, EmbeddingResult};
@@ -30,18 +30,10 @@ impl Embedder {
         token: Option<&str>,
         dtype: Option<Dtype>,
     ) -> Result<Self> {
-        let api = hf_hub::api::sync::ApiBuilder::from_env()
-            .with_token(token.map(|s| s.to_string()))
-            .build()?;
-        let api = match revision {
-            Some(rev) => api.repo(Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(Repo::new(model_id.to_string(), hf_hub::RepoType::Model)),
-        };
-        let config_filename = api.get("config.json")?;
+        let client = HubClient::new(token)?;
+        let repo = client.model(model_id, revision);
+        let config_filename = repo.get("config.json")?;
+
         let config = std::fs::read_to_string(config_filename)?;
         let config: serde_json::Value = serde_json::from_str(&config)?;
 

--- a/crates/opennote-embedder/crates/embed/src/embeddings/hub.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/hub.rs
@@ -1,0 +1,133 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use hf_hub::{HFClientBuilder, HFClientSync, HFError, HFRepositorySync, RepoTypeModel};
+
+pub const HUGGINGFACE_CHINESE_MIRROR: &str = "https://hf-mirror.com";
+
+/// Test the connectivity between the computer and huggingface
+pub fn is_huggingface_connected() -> bool {
+    tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(async {
+            let client = reqwest::Client::new();
+
+            match client.get("https://huggingface.co").send().await {
+                Ok(_) => true,
+                Err(_) => false,
+            }
+        })
+    })
+}
+
+/// Blocking Hugging Face Hub client shared by model repositories created during one load.
+#[derive(Clone)]
+pub(crate) struct HubClient {
+    inner: HFClientSync,
+}
+
+impl HubClient {
+    pub(crate) fn new(token: Option<&str>) -> Result<Self> {
+        let endpoint = match is_huggingface_connected() {
+            true => None,
+            false => Some(HUGGINGFACE_CHINESE_MIRROR),
+        };
+
+        let mut builder = HFClientBuilder::new();
+
+        if let Some(endpoint) = endpoint {
+            builder = builder.endpoint(endpoint);
+        }
+
+        if let Some(token) = token {
+            builder = builder.token(token);
+        }
+
+        Ok(Self {
+            inner: builder.build_sync()?,
+        })
+    }
+
+    pub(crate) fn model(&self, model_id: &str, revision: Option<&str>) -> HubModelRepo {
+        let (owner, name) = hf_hub::split_id(model_id);
+        HubModelRepo {
+            inner: self.inner.model(owner, name),
+            revision: revision.map(str::to_owned),
+        }
+    }
+}
+
+/// A model repository with its revision attached to every file download.
+#[derive(Clone)]
+pub(crate) struct HubModelRepo {
+    inner: HFRepositorySync<RepoTypeModel>,
+    revision: Option<String>,
+}
+
+impl HubModelRepo {
+    pub(crate) fn new(model_id: &str, revision: Option<&str>, token: Option<&str>) -> Result<Self> {
+        Ok(HubClient::new(token)?.model(model_id, revision))
+    }
+
+    pub(crate) fn get(&self, filename: &str) -> hf_hub::HFResult<PathBuf> {
+        self.inner
+            .download_file()
+            .filename(filename)
+            .maybe_revision(self.revision.clone())
+            .send()
+    }
+
+    pub(crate) fn optional(&self, filename: &str) -> hf_hub::HFResult<Option<PathBuf>> {
+        match self.get(filename) {
+            Ok(path) => Ok(Some(path)),
+            Err(HFError::EntryNotFound { .. }) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Returns the first existing file, falling through only when a file is absent.
+    pub(crate) fn first_available(&self, filenames: &[&str]) -> hf_hub::HFResult<PathBuf> {
+        let mut last_missing = None;
+        for filename in filenames {
+            match self.get(filename) {
+                Ok(path) => return Ok(path),
+                Err(error @ HFError::EntryNotFound { .. }) => last_missing = Some(error),
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(last_missing.unwrap_or_else(|| {
+            HFError::InvalidParameter("at least one Hub filename is required".to_string())
+        }))
+    }
+
+    pub(crate) fn safetensor_shards(&self, index_filename: &str) -> Result<Vec<PathBuf>> {
+        let index_path = self
+            .get(index_filename)
+            .with_context(|| format!("failed to download safetensors index {index_filename}"))?;
+        let index_file = std::fs::File::open(&index_path).with_context(|| {
+            format!("failed to open safetensors index {}", index_path.display())
+        })?;
+        let index: serde_json::Value = serde_json::from_reader(index_file).with_context(|| {
+            format!("failed to parse safetensors index {}", index_path.display())
+        })?;
+        let weight_map = index
+            .get("weight_map")
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| anyhow!("weight_map is missing from {}", index_path.display()))?;
+
+        let mut filenames: Vec<&str> = weight_map
+            .values()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
+        filenames.sort_unstable();
+        filenames.dedup();
+
+        filenames
+            .into_iter()
+            .map(|filename| {
+                self.get(filename)
+                    .with_context(|| format!("failed to download safetensors shard {filename}"))
+            })
+            .collect()
+    }
+}

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/bert.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/bert.rs
@@ -7,6 +7,7 @@ extern crate accelerate_src;
 use std::collections::HashMap;
 
 use crate::embeddings::embed::EmbeddingResult;
+use crate::embeddings::hub::HubModelRepo;
 use crate::embeddings::local::text_embedding::get_model_info_by_hf_id;
 use crate::embeddings::utils::tokenize_batch;
 use crate::embeddings::{normalize_l2, select_device};
@@ -14,8 +15,6 @@ use anyhow::Error as E;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{BertForMaskedLM, BertModel, Config, DTYPE};
-use hf_hub::Repo;
-use hf_hub::api::sync::ApiBuilder;
 
 use serde::Deserialize;
 use tokenizers::{AddedToken, PaddingParams, Tokenizer, TruncationParams};
@@ -77,31 +76,10 @@ impl BertEmbedder {
         };
 
         let (config_filename, tokenizer_filename, weights_filename) = {
-            let api = ApiBuilder::from_env()
-                .with_token(token.map(|s| s.to_string()))
-                .build()
-                .unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(model_id, hf_hub::RepoType::Model, rev)),
-                None => api.repo(hf_hub::Repo::new(
-                    model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let weights = match api.get("model.safetensors") {
-                Ok(safetensors) => safetensors,
-                Err(_) => match api.get("pytorch_model.bin") {
-                    Ok(pytorch_model) => pytorch_model,
-                    Err(e) => {
-                        return Err(anyhow::Error::msg(format!(
-                            "Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {}",
-                            e
-                        )));
-                    }
-                },
-            };
+            let repo = HubModelRepo::new(&model_id, revision.as_deref(), token)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let weights = repo.first_available(&["model.safetensors", "pytorch_model.bin"])?;
 
             (config, tokenizer, weights)
         };
@@ -299,31 +277,10 @@ pub struct SparseBertEmbedder {
 impl SparseBertEmbedder {
     pub fn new(model_id: String, revision: Option<String>, token: Option<&str>) -> Result<Self, E> {
         let (config_filename, tokenizer_filename, weights_filename) = {
-            let api = ApiBuilder::from_env()
-                .with_token(token.map(|s| s.to_string()))
-                .build()
-                .unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(model_id, hf_hub::RepoType::Model, rev)),
-                None => api.repo(hf_hub::Repo::new(
-                    model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let weights = match api.get("model.safetensors") {
-                Ok(safetensors) => safetensors,
-                Err(_) => match api.get("pytorch_model.bin") {
-                    Ok(pytorch_model) => pytorch_model,
-                    Err(e) => {
-                        return Err(anyhow::Error::msg(format!(
-                            "Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {}",
-                            e
-                        )));
-                    }
-                },
-            };
+            let repo = HubModelRepo::new(&model_id, revision.as_deref(), token)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let weights = repo.first_available(&["model.safetensors", "pytorch_model.bin"])?;
 
             (config, tokenizer, weights)
         };

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/clip.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/clip.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, fs};
 use anyhow::Error as E;
 
 use crate::{
-    embeddings::{embed::EmbeddingResult, select_device},
+    embeddings::{embed::EmbeddingResult, hub::HubModelRepo, select_device},
     models::{
         clip::div_l2_norm,
         clip::{self, ClipConfig},
@@ -77,43 +77,24 @@ impl Default for ClipEmbedder {
 
 impl ClipEmbedder {
     pub fn new(model_id: String, revision: Option<&str>, token: Option<&str>) -> Result<Self, E> {
-        let api = hf_hub::api::sync::ApiBuilder::from_env()
-            .with_token(token.map(|s| s.to_string()))
-            .build()?;
-
-        let api = match revision {
-            Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
+        let repo = HubModelRepo::new(&model_id, revision, token)?;
 
         let device = select_device();
 
-        let vb = match api.get("model.safetensors") {
-            Ok(safetensors) => unsafe {
-                VarBuilder::from_mmaped_safetensors(&[safetensors], DType::F32, &device)?
-            },
-            Err(_) => match api.get("pytorch_model.bin") {
-                Ok(pytorch_model) => VarBuilder::from_pth(pytorch_model, DType::F32, &device)?,
-                Err(e) => {
-                    return Err(anyhow::Error::msg(format!(
-                        "Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {}",
-                        e
-                    )));
-                }
-            },
+        let weights_filename = repo.first_available(&["model.safetensors", "pytorch_model.bin"])?;
+        let vb = if weights_filename.ends_with("model.safetensors") {
+            unsafe {
+                VarBuilder::from_mmaped_safetensors(&[weights_filename], DType::F32, &device)?
+            }
+        } else {
+            VarBuilder::from_pth(weights_filename, DType::F32, &device)?
         };
-        let config_filename = api.get("config.json")?;
+        let config_filename = repo.get("config.json")?;
         let config_str = std::fs::read_to_string(config_filename)?;
         let config_json: serde_json::Value = serde_json::from_str(&config_str)?;
 
-        let mut tokenizer = Self::get_tokenizer(None, model_id, revision)?;
+        let tokenizer_filename = repo.get("tokenizer.json")?;
+        let mut tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         let pp = PaddingParams {
             strategy: tokenizers::PaddingStrategy::BatchLongest,
             ..Default::default()
@@ -204,18 +185,7 @@ impl ClipEmbedder {
         revision: Option<&str>,
     ) -> anyhow::Result<Tokenizer> {
         let tokenizer = match tokenizer {
-            None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = match revision {
-                    Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                        model_id,
-                        hf_hub::RepoType::Model,
-                        rev.to_string(),
-                    )),
-                    None => api.repo(hf_hub::Repo::new(model_id, hf_hub::RepoType::Model)),
-                };
-                api.get("tokenizer.json")?
-            }
+            None => HubModelRepo::new(&model_id, revision, None)?.get("tokenizer.json")?,
             Some(file) => file.into(),
         };
 

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/colbert.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/colbert.rs
@@ -7,7 +7,6 @@ extern crate accelerate_src;
 use std::{ops::Mul, sync::RwLock};
 
 use anyhow::{Error as E, Result};
-use hf_hub::{Repo, api::sync::Api};
 use ndarray::{Array2, Axis};
 use ort::{
     execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider},
@@ -16,7 +15,7 @@ use ort::{
 };
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
-use crate::embeddings::{embed::EmbeddingResult, utils::tokenize_batch_ndarray};
+use crate::embeddings::{embed::EmbeddingResult, hub::HubModelRepo, utils::tokenize_batch_ndarray};
 
 use super::bert::{BertEmbed, TokenizerConfig};
 
@@ -52,24 +51,13 @@ impl OrtColbertEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename, data_filename) = {
-            let api = Api::new().unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                    rev.to_string(),
-                )),
-                None => api.repo(hf_hub::Repo::new(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let tokenizer_config = api.get("tokenizer_config.json")?;
+            let repo = HubModelRepo::new(hf_model_id, revision, None)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let tokenizer_config = repo.get("tokenizer_config.json")?;
 
-            let weights = api.get(path_in_repo);
-            let data = api.get(format!("{path_in_repo}_data").as_str());
+            let weights = repo.get(path_in_repo);
+            let data = repo.optional(format!("{path_in_repo}_data").as_str())?;
 
             (config, tokenizer, weights, tokenizer_config, data)
         };
@@ -84,7 +72,7 @@ impl OrtColbertEmbedder {
             }
         };
 
-        let _ = data_filename.ok();
+        let _ = data_filename;
 
         let tokenizer_config = std::fs::read_to_string(tokenizer_config_filename)?;
         let tokenizer_config: TokenizerConfig = serde_json::from_str(&tokenizer_config)?;

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/colpali.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/colpali.rs
@@ -3,6 +3,7 @@ use std::sync::RwLock;
 use std::{collections::HashMap, path::Path};
 
 use crate::embeddings::embed::{EmbedData, EmbeddingResult};
+use crate::embeddings::hub::HubClient;
 use crate::embeddings::select_device;
 use crate::models::{colpali::Model, paligemma};
 use anyhow::Error as E;
@@ -43,27 +44,13 @@ pub struct ColPaliEmbedder {
 
 impl ColPaliEmbedder {
     pub fn new(model_id: &str, revision: Option<&str>) -> Result<Self, anyhow::Error> {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo: hf_hub::api::sync::ApiRepo = match revision {
-            Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
-
-        let tokenizer_api = api.repo(hf_hub::Repo::new(
-            "vidore/colpali".to_string(),
-            hf_hub::RepoType::Model,
-        ));
+        let hub = HubClient::new(None)?;
+        let repo = hub.model(model_id, revision);
+        let tokenizer_repo = hub.model("vidore/colpali", None);
 
         let (tokenizer_filename, weights_filename) = {
-            let tokenizer = tokenizer_api.get("tokenizer.json")?;
-            let weights = hub_load_safetensors(&repo, "model.safetensors.index.json")?;
+            let tokenizer = tokenizer_repo.get("tokenizer.json")?;
+            let weights = repo.safetensor_shards("model.safetensors.index.json")?;
 
             (tokenizer, weights)
         };
@@ -294,32 +281,6 @@ fn tokenize_batch(
         .collect::<candle_core::Result<Vec<_>>>()?;
 
     Ok(Tensor::stack(&token_ids, 0)?)
-}
-
-pub fn hub_load_safetensors(
-    repo: &hf_hub::api::sync::ApiRepo,
-    json_file: &str,
-) -> Result<Vec<std::path::PathBuf>, E> {
-    let json_file = repo.get(json_file).map_err(candle_core::Error::wrap)?;
-    let json_file = std::fs::File::open(json_file)?;
-    let json: serde_json::Value =
-        serde_json::from_reader(&json_file).map_err(candle_core::Error::wrap)?;
-    let weight_map = match json.get("weight_map") {
-        None => anyhow::bail!("no weight map in {json_file:?}"),
-        Some(serde_json::Value::Object(map)) => map,
-        Some(_) => anyhow::bail!("weight map in {json_file:?} is not a map"),
-    };
-    let mut safetensors_files = std::collections::HashSet::new();
-    for value in weight_map.values() {
-        if let Some(file) = value.as_str() {
-            safetensors_files.insert(file.to_string());
-        }
-    }
-    let safetensors_files = safetensors_files
-        .iter()
-        .map(|v| repo.get(v).map_err(candle_core::Error::wrap))
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(safetensors_files)
 }
 
 pub fn load_image<T: AsRef<std::path::Path>>(

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/colpali_ort.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/colpali_ort.rs
@@ -14,6 +14,7 @@ use rayon::prelude::*;
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
 use crate::embeddings::embed::{EmbedData, EmbeddingResult};
+use crate::embeddings::hub::HubModelRepo;
 
 use super::colpali::{ColPaliEmbed, get_images_from_pdf};
 
@@ -31,32 +32,17 @@ impl OrtColPaliEmbedder {
         revision: Option<&str>,
         path_in_repo: Option<&str>,
     ) -> Result<Self, E> {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo: hf_hub::api::sync::ApiRepo = match revision {
-            Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
+        let repo = HubModelRepo::new(model_id, revision, None)?;
 
         let mut path_in_repo = path_in_repo.unwrap_or_default().to_string();
         if !path_in_repo.is_empty() {
             path_in_repo.push('/');
         }
         let (_, tokenizer_filename, weights_filename, _) = {
-            let config = repo
-                .get("config.json")
-                .unwrap_or(repo.get("preprocessor_config.json")?);
+            let config = repo.first_available(&["config.json", "preprocessor_config.json"])?;
             let tokenizer = repo.get("tokenizer.json")?;
             let weights = repo.get(format!("{}model.onnx", path_in_repo).as_str())?;
-            let data = repo
-                .get(format!("{}model.onnx_data", path_in_repo).as_str())
-                .ok();
+            let data = repo.optional(format!("{}model.onnx_data", path_in_repo).as_str())?;
 
             (config, tokenizer, weights, data)
         };

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/colsmol.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/colsmol.rs
@@ -8,6 +8,7 @@ use candle_nn::VarBuilder;
 use image::ImageFormat;
 
 use crate::embeddings::embed::{EmbedData, EmbeddingResult};
+use crate::embeddings::hub::HubClient;
 use crate::embeddings::local::colpali::{ColPaliEmbed, get_images_from_pdf};
 use crate::embeddings::select_device;
 use crate::models::idefics3::model::{ColIdefics3Model, Idefics3Config};
@@ -21,18 +22,8 @@ pub struct ColSmolEmbedder {
 
 impl ColSmolEmbedder {
     pub fn new(model_id: &str, revision: Option<&str>) -> Result<Self, anyhow::Error> {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo: hf_hub::api::sync::ApiRepo = match revision {
-            Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
+        let hub = HubClient::new(None)?;
+        let repo = hub.model(model_id, revision);
 
         let model_file = repo.get("model.safetensors")?;
         let device = select_device();
@@ -45,7 +36,8 @@ impl ColSmolEmbedder {
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
         let config_file = repo.get("config.json")?;
 
-        let processor = Idefics3Processor::from_pretrained("akshayballal/colSmol-256M-merged")?;
+        let processor_repo = hub.model("akshayballal/colSmol-256M-merged", None);
+        let processor = Idefics3Processor::from_repo(&processor_repo)?;
         let config: Idefics3Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
 
         let model = ColIdefics3Model::load(&config, false, vb)?;

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/jina.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/jina.rs
@@ -6,6 +6,7 @@ extern crate accelerate_src;
 
 use super::bert::TokenizerConfig;
 use super::pooling::{ModelOutput, PooledOutputType, Pooling};
+use crate::embeddings::hub::HubModelRepo;
 use crate::embeddings::select_device;
 use crate::embeddings::utils::tokenize_batch;
 use crate::embeddings::{embed::EmbeddingResult, normalize_l2};
@@ -13,7 +14,6 @@ use crate::models::jina_bert::{BertModel, Config};
 use anyhow::Error as E;
 use candle_core::{DType, Tensor};
 use candle_nn::{Module, VarBuilder};
-use hf_hub::Repo;
 
 use tokenizers::Tokenizer;
 
@@ -50,21 +50,11 @@ impl Default for JinaEmbedder {
 
 impl JinaEmbedder {
     pub fn new(model_id: &str, revision: Option<&str>, token: Option<&str>) -> Result<Self, E> {
-        let api = hf_hub::api::sync::ApiBuilder::from_env()
-            .with_token(token.map(|s| s.to_string()))
-            .build()?;
-        let api = match revision {
-            Some(rev) => api.repo(Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(Repo::new(model_id.to_string(), hf_hub::RepoType::Model)),
-        };
+        let repo = HubModelRepo::new(model_id, revision, token)?;
 
-        let config_filename = api.get("config.json")?;
-        let tokenizer_filename = api.get("tokenizer.json")?;
-        let tokenizer_config_filename = api.get("tokenizer_config.json")?;
+        let config_filename = repo.get("config.json")?;
+        let tokenizer_filename = repo.get("tokenizer.json")?;
+        let tokenizer_config_filename = repo.get("tokenizer_config.json")?;
         let mut tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
 
         let tokenizer_config = std::fs::read_to_string(tokenizer_config_filename)?;
@@ -84,19 +74,13 @@ impl JinaEmbedder {
         let config = std::fs::read_to_string(config_filename)?;
         let config: Config = serde_json::from_str(&config)?;
         let device = select_device();
-        let vb = match api.get("model.safetensors") {
-            Ok(safetensors) => unsafe {
-                VarBuilder::from_mmaped_safetensors(&[safetensors], DType::F32, &device)?
-            },
-            Err(_) => match api.get("pytorch_model.bin") {
-                Ok(pytorch_model) => VarBuilder::from_pth(pytorch_model, DType::F32, &device)?,
-                Err(e) => {
-                    return Err(anyhow::Error::msg(format!(
-                        "Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {}",
-                        e
-                    )));
-                }
-            },
+        let weights_filename = repo.first_available(&["model.safetensors", "pytorch_model.bin"])?;
+        let vb = if weights_filename.ends_with("model.safetensors") {
+            unsafe {
+                VarBuilder::from_mmaped_safetensors(&[weights_filename], DType::F32, &device)?
+            }
+        } else {
+            VarBuilder::from_pth(weights_filename, DType::F32, &device)?
         };
         let model = BertModel::new(vb, &config)?;
         // let mut tokenizer = Self::get_tokenizer(None)?;

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/modernbert.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/modernbert.rs
@@ -1,12 +1,12 @@
 use crate::{
     Dtype,
-    embeddings::{normalize_l2, utils::tokenize_batch},
+    embeddings::{hub::HubModelRepo, normalize_l2, utils::tokenize_batch},
     models::modernbert::{Config, ModernBert},
 };
 use anyhow::Error as E;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{Repo, api::sync::ApiBuilder};
+
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
 use crate::embeddings::{embed::EmbeddingResult, select_device};
@@ -41,31 +41,10 @@ impl ModernBertEmbedder {
         dtype: Option<Dtype>,
     ) -> Result<Self, E> {
         let (config_filename, tokenizer_filename, weights_filename) = {
-            let api = ApiBuilder::from_env()
-                .with_token(token.map(|s| s.to_string()))
-                .build()
-                .unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(model_id, hf_hub::RepoType::Model, rev)),
-                None => api.repo(hf_hub::Repo::new(
-                    model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let weights = match api.get("model.safetensors") {
-                Ok(safetensors) => safetensors,
-                Err(_) => match api.get("pytorch_model.bin") {
-                    Ok(pytorch_model) => pytorch_model,
-                    Err(e) => {
-                        return Err(anyhow::Error::msg(format!(
-                            "Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {}",
-                            e
-                        )));
-                    }
-                },
-            };
+            let repo = HubModelRepo::new(&model_id, revision.as_deref(), token)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let weights = repo.first_available(&["model.safetensors", "pytorch_model.bin"])?;
 
             (config, tokenizer, weights)
         };

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/ort_bert.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/ort_bert.rs
@@ -4,13 +4,12 @@ use super::bert::{BertEmbed, TokenizerConfig};
 use super::pooling::{ModelOutput, PooledOutputType, Pooling};
 use super::text_embedding::ONNXModel;
 use crate::embeddings::embed::EmbeddingResult;
+use crate::embeddings::hub::HubModelRepo;
 use crate::embeddings::local::text_embedding::models_map;
 use crate::embeddings::utils::{get_type_ids_ndarray, tokenize_batch_ndarray};
 
 use crate::Dtype;
 use anyhow::Error as E;
-use hf_hub::Repo;
-use hf_hub::api::sync::Api;
 use ndarray::prelude::*;
 use ort::execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider};
 use ort::session::Session;
@@ -62,21 +61,10 @@ impl OrtBertEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                    rev.to_string(),
-                )),
-                None => api.repo(hf_hub::Repo::new(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let tokenizer_config = api.get("tokenizer_config.json")?;
+            let repo = HubModelRepo::new(hf_model_id, revision, None)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let tokenizer_config = repo.get("tokenizer_config.json")?;
             let mut base_path = path
                 .rsplit_once('/')
                 .map(|(p, _)| p.to_string())
@@ -96,7 +84,7 @@ impl OrtBertEmbedder {
                 Some(Dtype::BF16) => format!("{base_path}model_bf16.onnx"),
                 None => path.to_string(),
             };
-            let weights = api.get(model_path.as_str());
+            let weights = repo.get(model_path.as_str());
             (config, tokenizer, weights, tokenizer_config)
         };
 
@@ -421,22 +409,11 @@ impl OrtSparseBertEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                    rev.to_string(),
-                )),
-                None => api.repo(hf_hub::Repo::new(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let tokenizer_config = api.get("tokenizer_config.json")?;
-            let weights = api.get(path)?;
+            let repo = HubModelRepo::new(hf_model_id, revision, None)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let tokenizer_config = repo.get("tokenizer_config.json")?;
+            let weights = repo.get(path)?;
             (config, tokenizer, weights, tokenizer_config)
         };
         let tokenizer_config = std::fs::read_to_string(tokenizer_config_filename)?;

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/ort_colsmol.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/ort_colsmol.rs
@@ -2,6 +2,7 @@ use std::sync::RwLock;
 use std::{collections::HashMap, path::PathBuf};
 
 use crate::embeddings::embed::{EmbedData, EmbeddingResult};
+use crate::embeddings::hub::HubModelRepo;
 use crate::embeddings::local::colpali::ColPaliEmbed;
 use crate::models::idefics3::array_processing::Idefics3Processor;
 use crate::models::paligemma;
@@ -11,13 +12,12 @@ use half::f16;
 use image::ImageFormat;
 use ndarray::prelude::*;
 use ort::execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider};
-use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
+use ort::session::builder::GraphOptimizationLevel;
 use rayon::prelude::*;
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
 use super::colpali::get_images_from_pdf;
-
 
 pub struct OrtColSmolEmbedder {
     pub model: RwLock<Session>,
@@ -34,32 +34,17 @@ impl OrtColSmolEmbedder {
         revision: Option<&str>,
         path_in_repo: Option<&str>,
     ) -> Result<Self, E> {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo: hf_hub::api::sync::ApiRepo = match revision {
-            Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
+        let repo = HubModelRepo::new(model_id, revision, None)?;
 
         let mut path_in_repo = path_in_repo.unwrap_or_default().to_string();
         if !path_in_repo.is_empty() {
             path_in_repo.push('/');
         }
-        let (_, tokenizer_filename, weights_filename, _, processing_config_filename,) = {
-            let config = repo
-                .get("config.json")
-                .unwrap_or(repo.get("preprocessor_config.json")?);
+        let (_, tokenizer_filename, weights_filename, _, processing_config_filename) = {
+            let config = repo.first_available(&["config.json", "preprocessor_config.json"])?;
             let tokenizer = repo.get("tokenizer.json")?;
             let weights = repo.get(format!("{}model.onnx", path_in_repo).as_str())?;
-            let data = repo
-                .get(format!("{}model.onnx_data", path_in_repo).as_str())
-                .ok();
+            let data = repo.optional(format!("{}model.onnx_data", path_in_repo).as_str())?;
             let processing_config = repo.get("preprocessor_config.json")?;
 
             (config, tokenizer, weights, data, processing_config)
@@ -68,7 +53,7 @@ impl OrtColSmolEmbedder {
         let config: paligemma::Config = paligemma::Config::paligemma_3b_448();
         let image_size = config.vision_config.image_size;
         let num_channels = config.vision_config.num_channels;
-        
+
         let mut tokenizer = Tokenizer::from_pretrained(model_id, None).map_err(E::msg)?;
 
         let pp = PaddingParams {
@@ -87,7 +72,6 @@ impl OrtColSmolEmbedder {
             .with_padding(Some(pp))
             .with_truncation(Some(trunc))
             .unwrap();
-
 
         let cuda = CUDAExecutionProvider::default();
 
@@ -293,7 +277,8 @@ impl ColPaliEmbed for OrtColSmolEmbedder {
             let start_page = index * batch_size + 1;
             let end_page = start_page + batch.len();
             let page_numbers = (start_page..=end_page).collect::<Vec<_>>();
-            let (input_ids, attention_mask, page_images, pixel_attention_mask) = self.processor.preprocess(&batch)?;
+            let (input_ids, attention_mask, page_images, pixel_attention_mask) =
+                self.processor.preprocess(&batch)?;
 
             let image_embeddings = self.run_model(
                 input_ids,
@@ -337,8 +322,9 @@ impl ColPaliEmbed for OrtColSmolEmbedder {
         metadata: Option<std::collections::HashMap<String, String>>,
     ) -> anyhow::Result<EmbedData> {
         let image = image::open(&image_path)?;
-        let (input_ids, attention_mask, image_array, pixel_attention_mask) = self.processor.preprocess(&[image])?;
-   
+        let (input_ids, attention_mask, image_array, pixel_attention_mask) =
+            self.processor.preprocess(&[image])?;
+
         println!("image array shape: {:?}", image_array.shape());
         println!("input ids {:?}", input_ids);
         let e = self
@@ -362,7 +348,8 @@ impl ColPaliEmbed for OrtColSmolEmbedder {
             .iter()
             .map(|path| image::open(path).unwrap())
             .collect::<Vec<_>>();
-        let (input_ids, attention_mask, image_array, pixel_attention_mask) = self.processor.preprocess(&images)?;
+        let (input_ids, attention_mask, image_array, pixel_attention_mask) =
+            self.processor.preprocess(&images)?;
 
         let e = self
             .run_model(

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/ort_jina.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/ort_jina.rs
@@ -4,10 +4,9 @@ use super::pooling::{ModelOutput, PooledOutputType, Pooling};
 use super::text_embedding::{ONNXModel, models_map};
 use crate::Dtype;
 use crate::embeddings::embed::EmbeddingResult;
+use crate::embeddings::hub::HubModelRepo;
 use crate::embeddings::utils::tokenize_batch_ndarray;
 use anyhow::Error as E;
-use hf_hub::Repo;
-use hf_hub::api::sync::Api;
 use ndarray::prelude::*;
 use std::sync::RwLock;
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
@@ -63,21 +62,10 @@ impl OrtJinaEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                    rev.to_string(),
-                )),
-                None => api.repo(hf_hub::Repo::new(
-                    hf_model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let tokenizer_config = api.get("tokenizer_config.json")?;
+            let repo = HubModelRepo::new(hf_model_id, revision, None)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let tokenizer_config = repo.get("tokenizer_config.json")?;
             let mut base_path = path
                 .rsplit_once('/')
                 .map(|(p, _)| p.to_string())
@@ -97,8 +85,8 @@ impl OrtJinaEmbedder {
                 Some(Dtype::BF16) => format!("{base_path}model_bf16.onnx"),
                 None => path.to_string(),
             };
-            let weights = api.get(model_path.as_str());
-            let _ = api.get(format!("{path}_data").as_str());
+            let weights = repo.get(model_path.as_str());
+            let _ = repo.optional(format!("{path}_data").as_str())?;
 
             (config, tokenizer, weights, tokenizer_config)
         };

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/qwen3.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/qwen3.rs
@@ -5,19 +5,19 @@ extern crate intel_mkl_src;
 extern crate accelerate_src;
 
 use crate::{
-    embeddings::{embed::EmbeddingResult, normalize_l2, select_device, utils::tokenize_batch},
+    embeddings::{
+        embed::EmbeddingResult, hub::HubModelRepo, normalize_l2, select_device,
+        utils::tokenize_batch,
+    },
     models::qwen3::{Config, Model},
 };
 use anyhow::Error;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{Repo, api::sync::ApiBuilder};
+
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
-use super::{
-    colpali::hub_load_safetensors,
-    pooling::{ModelOutput, PooledOutputType, Pooling},
-};
+use super::pooling::{ModelOutput, PooledOutputType, Pooling};
 
 pub trait Qwen3Embed {
     fn embed(
@@ -41,26 +41,12 @@ impl Qwen3Embedder {
         token: Option<&str>,
         dtype: Option<crate::Dtype>,
     ) -> Result<Self, anyhow::Error> {
-        let api = ApiBuilder::from_env()
-            .with_token(token.map(|s| s.to_string()))
-            .build()
-            .unwrap();
-
-        let repo = match revision {
-            Some(rev) => api.repo(Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev,
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
+        let repo = HubModelRepo::new(model_id, revision.as_deref(), token)?;
         let (config_filename, tokenizer_filename, weights_filename) = {
             let config = repo.get("config.json")?;
             let tokenizer = repo.get("tokenizer.json")?;
-            let weights = repo.get("model.safetensors");
+            let weights =
+                repo.first_available(&["model.safetensors", "model.safetensors.index.json"])?;
 
             (config, tokenizer, weights)
         };
@@ -93,15 +79,12 @@ impl Qwen3Embedder {
             _ => DType::F32,
         };
 
-        let vb = match weights_filename {
-            Ok(weights) => unsafe {
-                VarBuilder::from_mmaped_safetensors(&[weights], dtype, &device)?
-            },
-            Err(_) => {
-                let weights = hub_load_safetensors(&repo, "model.safetensors.index.json")?;
-                unsafe { VarBuilder::from_mmaped_safetensors(&weights, dtype, &device)? }
-            }
+        let weights = if weights_filename.ends_with("model.safetensors") {
+            vec![weights_filename]
+        } else {
+            repo.safetensor_shards("model.safetensors.index.json")?
         };
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&weights, dtype, &device)? };
 
         let model = Model::new(&config, vb)?;
 

--- a/crates/opennote-embedder/crates/embed/src/embeddings/local/vision_encoder.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/local/vision_encoder.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, fs};
 use anyhow::Error as E;
 
 use crate::{
-    embeddings::{embed::EmbeddingResult, select_device},
+    embeddings::{embed::EmbeddingResult, hub::HubModelRepo, select_device},
     models::clip::div_l2_norm,
 };
 use candle_core::{DType, Device, Tensor};
@@ -43,43 +43,23 @@ impl Default for VisionEncoderEmbedder {
 
 impl VisionEncoderEmbedder {
     pub fn new(model_id: &str, revision: Option<&str>, token: Option<&str>) -> Result<Self, E> {
-        let api = hf_hub::api::sync::ApiBuilder::from_env()
-            .with_token(token.map(|s| s.to_string()))
-            .build()?;
-
-        let api = match revision {
-            Some(rev) => api.repo(hf_hub::Repo::with_revision(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-                rev.to_string(),
-            )),
-            None => api.repo(hf_hub::Repo::new(
-                model_id.to_string(),
-                hf_hub::RepoType::Model,
-            )),
-        };
+        let repo = HubModelRepo::new(model_id, revision, token)?;
 
         let device = select_device();
 
-        let vb = match api.get("model.safetensors") {
-            Ok(safetensors) => unsafe {
-                VarBuilder::from_mmaped_safetensors(&[safetensors], DType::F32, &device)?
-            },
-            Err(_) => match api.get("pytorch_model.bin") {
-                Ok(pytorch_model) => VarBuilder::from_pth(pytorch_model, DType::F32, &device)?,
-                Err(e) => {
-                    return Err(anyhow::Error::msg(format!(
-                        "Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {}",
-                        e
-                    )));
-                }
-            },
+        let weights_filename = repo.first_available(&["model.safetensors", "pytorch_model.bin"])?;
+        let vb = if weights_filename.ends_with("model.safetensors") {
+            unsafe {
+                VarBuilder::from_mmaped_safetensors(&[weights_filename], DType::F32, &device)?
+            }
+        } else {
+            VarBuilder::from_pth(weights_filename, DType::F32, &device)?
         };
-        let config_filename = api.get("config.json")?;
+        let config_filename = repo.get("config.json")?;
         let config_str = std::fs::read_to_string(config_filename)?;
         let config_json: serde_json::Value = serde_json::from_str(&config_str)?;
 
-        let preprocessor_config_filename = api.get("preprocessor_config.json")?;
+        let preprocessor_config_filename = repo.get("preprocessor_config.json")?;
         let preprocessor_config_str = std::fs::read_to_string(preprocessor_config_filename)?;
         let preprocessor_config_json: serde_json::Value =
             serde_json::from_str(&preprocessor_config_str)?;

--- a/crates/opennote-embedder/crates/embed/src/embeddings/mod.rs
+++ b/crates/opennote-embedder/crates/embed/src/embeddings/mod.rs
@@ -7,6 +7,7 @@ use candle_core::{Device, Tensor};
 
 pub mod cloud;
 pub mod embed;
+pub(crate) mod hub;
 pub mod local;
 pub mod utils;
 

--- a/crates/opennote-embedder/crates/embed/src/models/idefics3/array_processing.rs
+++ b/crates/opennote-embedder/crates/embed/src/models/idefics3/array_processing.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
+use crate::embeddings::hub::{HubClient, HubModelRepo};
 use anyhow::{Error, Ok};
-use hf_hub::{api::sync::Api, Repo, RepoType};
-use image::{imageops::FilterType, DynamicImage, GenericImageView, RgbImage};
-use ndarray::{s, Array2};
+use image::{DynamicImage, GenericImageView, RgbImage, imageops::FilterType};
+use ndarray::{Array2, s};
 use regex::Regex;
 use serde::Deserialize;
 use tokenizers::{AddedToken, PaddingParams, Tokenizer, TruncationParams};
@@ -65,11 +65,13 @@ impl Idefics3ImageProcessor {
     }
 
     pub fn from_pretrained(model_id: &str) -> Result<Self, anyhow::Error> {
-        let api = Api::new()?;
-        let repo = api.repo(Repo::new(model_id.to_string(), RepoType::Model));
-        let config_file = repo.get("preprocessor_config.json").unwrap();
-        let processor: Idefics3ImageProcessor =
-            serde_json::from_slice(&std::fs::read(config_file).unwrap()).unwrap();
+        let repo = HubModelRepo::new(model_id, None, None)?;
+        Self::from_repo(&repo)
+    }
+
+    fn from_repo(repo: &HubModelRepo) -> Result<Self, anyhow::Error> {
+        let config_file = repo.get("preprocessor_config.json")?;
+        let processor = serde_json::from_slice(&std::fs::read(config_file)?)?;
         Ok(processor)
     }
 
@@ -495,8 +497,11 @@ pub struct Idefics3Processor {
 
 impl Idefics3Processor {
     pub fn from_pretrained(model_id: &str) -> anyhow::Result<Self> {
-        let image_processor = Idefics3ImageProcessor::from_pretrained(model_id)?;
-        let mut tokenizer = Tokenizer::from_pretrained(model_id, None)
+        let hub = HubClient::new(None)?;
+        let repo = hub.model(model_id, None);
+        let image_processor = Idefics3ImageProcessor::from_repo(&repo)?;
+        let tokenizer_file = repo.get("tokenizer.json")?;
+        let mut tokenizer = Tokenizer::from_file(tokenizer_file)
             .map_err(|e| anyhow::anyhow!("Tokenizer error: {}", e))?;
         let fake_image_token = AddedToken::from("<fake_token_around_image>", true);
         let image_token = AddedToken::from("<image>", true);
@@ -692,8 +697,6 @@ fn normalize(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hf_hub::api::sync::Api;
-    use hf_hub::{Repo, RepoType};
     use image::RgbImage;
 
     #[test]
@@ -701,11 +704,7 @@ mod tests {
         let image = image::open("/home/akshay/projects/EmbedAnything/test.jpg").unwrap();
         let image_array = image.to_rgb8().into_raw();
 
-        let api = Api::new().unwrap();
-        let repo = api.repo(Repo::new(
-            "onnx-community/colSmol-256M-ONNX".to_string(),
-            RepoType::Model,
-        ));
+        let repo = HubModelRepo::new("onnx-community/colSmol-256M-ONNX", None, None).unwrap();
         let config_file = repo.get("preprocessor_config.json").unwrap();
         let processor: Idefics3ImageProcessor =
             serde_json::from_slice(&std::fs::read(config_file).unwrap()).unwrap();

--- a/crates/opennote-embedder/crates/embed/src/models/idefics3/tensor_processing.rs
+++ b/crates/opennote-embedder/crates/embed/src/models/idefics3/tensor_processing.rs
@@ -1,5 +1,5 @@
+use crate::embeddings::hub::{HubClient, HubModelRepo};
 use candle_core::{DType, Device, Tensor};
-use hf_hub::{Repo, RepoType, api::sync::Api};
 use image::{DynamicImage, GenericImageView, RgbImage, imageops::FilterType};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -503,8 +503,11 @@ impl Idefics3ImageProcessor {
     }
 
     pub fn from_pretrained(model_id: &str) -> Result<Self, anyhow::Error> {
-        let api = Api::new()?;
-        let repo = api.repo(Repo::new(model_id.to_string(), RepoType::Model));
+        let repo = HubModelRepo::new(model_id, None, None)?;
+        Self::from_repo(&repo)
+    }
+
+    fn from_repo(repo: &HubModelRepo) -> Result<Self, anyhow::Error> {
         let config_file = repo.get("preprocessor_config.json")?;
         let processor: Idefics3ImageProcessor =
             serde_json::from_slice(&std::fs::read(config_file)?)
@@ -524,10 +527,13 @@ pub struct Idefics3Processor {
 
 impl Idefics3Processor {
     pub fn from_pretrained(model_id: &str) -> anyhow::Result<Self> {
-        let image_processor = Idefics3ImageProcessor::from_pretrained(model_id)?;
-        let api = Api::new()?;
-        let repo = api.repo(Repo::new(model_id.to_string(), RepoType::Model));
+        let hub = HubClient::new(None)?;
+        let repo = hub.model(model_id, None);
+        Self::from_repo(&repo)
+    }
 
+    pub(crate) fn from_repo(repo: &HubModelRepo) -> anyhow::Result<Self> {
+        let image_processor = Idefics3ImageProcessor::from_repo(repo)?;
         let processor_config_file = repo.get("processor_config.json")?;
         let processor_config: serde_json::Value =
             serde_json::from_slice(&std::fs::read(processor_config_file)?)?;

--- a/crates/opennote-embedder/crates/embed/src/reranker/model.rs
+++ b/crates/opennote-embedder/crates/embed/src/reranker/model.rs
@@ -2,7 +2,6 @@ use std::sync::RwLock;
 
 use anyhow::{Error as E, Result};
 use candle_core::{Device, Tensor};
-use hf_hub::{Repo, api::sync::Api};
 use ndarray::Array2;
 use ort::{
     execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider},
@@ -11,7 +10,10 @@ use ort::{
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
 use crate::Dtype;
-use crate::{embeddings::local::bert::TokenizerConfig, reranker::qwen3};
+use crate::{
+    embeddings::{hub::HubModelRepo, local::bert::TokenizerConfig},
+    reranker::qwen3,
+};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -41,37 +43,26 @@ impl Reranker {
         path_in_repo: Option<&str>,
     ) -> Result<Self, E> {
         let (config_filename, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
-            let api = match revision {
-                Some(rev) => api.repo(Repo::with_revision(
-                    model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                    rev.to_string(),
-                )),
-                None => api.repo(hf_hub::Repo::new(
-                    model_id.to_string(),
-                    hf_hub::RepoType::Model,
-                )),
-            };
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
-            let tokenizer_config = api.get("tokenizer_config.json")?;
+            let repo = HubModelRepo::new(model_id, revision, None)?;
+            let config = repo.get("config.json")?;
+            let tokenizer = repo.get("tokenizer.json")?;
+            let tokenizer_config = repo.get("tokenizer_config.json")?;
 
             let mut path_in_repo = path_in_repo.unwrap_or_default().to_string();
             if !path_in_repo.is_empty() {
                 path_in_repo.push('/');
             }
             let weights = match dtype {
-                Dtype::Q4F16 => api.get(format!("{}model_q4f16.onnx", path_in_repo).as_str())?,
-                Dtype::F16 => api.get(format!("{}model_fp16.onnx", path_in_repo).as_str())?,
-                Dtype::INT8 => api.get(format!("{}model_int8.onnx", path_in_repo).as_str())?,
-                Dtype::Q4 => api.get(format!("{}model_q4.onnx", path_in_repo).as_str())?,
-                Dtype::UINT8 => api.get(format!("{}model_uint8.onnx", path_in_repo).as_str())?,
-                Dtype::BNB4 => api.get(format!("{}model_bnb4.onnx", path_in_repo).as_str())?,
-                Dtype::F32 => api.get(format!("{}model.onnx", path_in_repo).as_str())?,
-                Dtype::BF16 => api.get(format!("{}model_bf16.onnx", path_in_repo).as_str())?,
+                Dtype::Q4F16 => repo.get(format!("{}model_q4f16.onnx", path_in_repo).as_str())?,
+                Dtype::F16 => repo.get(format!("{}model_fp16.onnx", path_in_repo).as_str())?,
+                Dtype::INT8 => repo.get(format!("{}model_int8.onnx", path_in_repo).as_str())?,
+                Dtype::Q4 => repo.get(format!("{}model_q4.onnx", path_in_repo).as_str())?,
+                Dtype::UINT8 => repo.get(format!("{}model_uint8.onnx", path_in_repo).as_str())?,
+                Dtype::BNB4 => repo.get(format!("{}model_bnb4.onnx", path_in_repo).as_str())?,
+                Dtype::F32 => repo.get(format!("{}model.onnx", path_in_repo).as_str())?,
+                Dtype::BF16 => repo.get(format!("{}model_bf16.onnx", path_in_repo).as_str())?,
                 Dtype::QUANTIZED => {
-                    api.get(format!("{}model_quantized.onnx", path_in_repo).as_str())?
+                    repo.get(format!("{}model_quantized.onnx", path_in_repo).as_str())?
                 }
             };
             (config, tokenizer, weights, tokenizer_config)


### PR DESCRIPTION
The old hf-hub used in EmbedAnything does not support Content-Range header. I updated the crate to 1.0.0. Since the new crate had completely changed its APIs, we created an adaptation layer to fit it into the existing codes. 

Now the app will switch to hf-mirror for downloading models if the official site is unreachable. 